### PR TITLE
fix for left analog joystick on rumblepad

### DIFF
--- a/controllers/logitech/rumblepad2.json
+++ b/controllers/logitech/rumblepad2.json
@@ -5,10 +5,10 @@
         {
             "name": "left",
             "x": {
-                "pin": 6
+                "pin": 0
             },
             "y": {
-                "pin": 4
+                "pin": 1
             }
         },
         {
@@ -23,23 +23,23 @@
     ],
     "buttons": [
         {
-            "value": 1,
-            "pin": 0,
+            "value": 6,
+            "pin": 4,
             "name": "dpadLeft"
         },
         {
-            "value": 254,
-            "pin": 0,
+            "value": 2,
+            "pin": 4,
             "name": "dpadRight"
         },
         {
-            "value": 254,
-            "pin": 1,
+            "value": 4,
+            "pin": 4,
             "name": "dpadDown"
         },
         {
-            "value": 1,
-            "pin": 1,
+            "value": 0,
+            "pin": 4,
             "name": "dpadUp"
         },
         {


### PR DESCRIPTION
Currently the JSON file assumes the "mode" button is pressed. This prevents continuous output from the left joystick. I think the better, more common use case is for the mode button to be unpressed, for the left joystick to output continuous data, and for the dpad to output discrete button events.