### PR TITLE
Add support for controller Logitech Gamepad F710

### DIFF
--- a/controllers/logitech/gamepadf710.json
+++ b/controllers/logitech/gamepadf710.json
@@ -1,0 +1,97 @@
+{
+    "vendorID": 1133,
+    "productID": 49695,
+    "joysticks": [
+        {
+            "name": "left",
+            "x": {
+                "pin": 0
+            },
+            "y": {
+                "pin": 2
+            }
+        },
+        {
+            "name": "right",
+            "x": {
+                "pin": 4
+            },
+            "y": {
+                "pin": 6
+            }
+        }
+    ],
+    "buttons": [
+        {
+            "value": 64,
+            "pin": 10,
+            "name": "back"
+        },
+        {
+            "value": 128,
+            "pin": 10,
+            "name": "start"
+        },
+        {
+            "value": 28,
+            "pin": 11,
+            "name": "leftLeft"
+        },
+      	{
+      	    "value": 4,
+      	    "pin": 11,
+      	    "name": "leftUp"
+      	},
+        {
+            "value": 12,
+            "pin": 11,
+            "name": "leftRight"
+        },
+        {
+            "value": 20,
+            "pin": 11,
+            "name": "leftDown"
+        },
+        {
+            "value": 4,
+            "pin": 10,
+            "name": "X"
+        },
+        {
+            "value": 8,
+            "pin": 10,
+            "name": "Y"
+        },
+        {
+            "value": 1,
+            "pin": 10,
+            "name": "A"
+        },
+        {
+            "value": 2,
+            "pin": 10,
+            "name": "B"
+        },
+        {
+            "value": 16,
+            "pin": 10,
+            "name": "LB"
+        },
+        {
+            "value": 32,
+            "pin": 10,
+            "name": "RB"
+        },
+        {
+            "value": 255,
+            "pin": 9,
+            "name": "LT"
+        },
+        {
+            "value": 0,
+            "pin": 9,
+            "name": "RT"
+        }
+    ]
+}
+


### PR DESCRIPTION
http://support.logitech.com/product/wireless-gamepad-f710

I considered the LT and RT buttons as binary inputs, but there is also a hexadecimal value associated to them that could be used.